### PR TITLE
Remove use of .grid__inner

### DIFF
--- a/templates/author/show.html.twig
+++ b/templates/author/show.html.twig
@@ -10,30 +10,26 @@
     <div class="component component--lined br-keyline">
         <div class="grid-wrapper">
             <div class="grid 1/3">
-                <div class="grid__inner">
-                    {{ ds('image', author.getImage(), 160, {}) }}
-                </div>
+                {{ ds('image', author.getImage(), 160, {}) }}
             </div>
             <div class="grid 2/3">
-                <div class="grid__inner">
-                    <h1 class="no-margin">{{ author.getName() }}</h1>
-                    <p>
-                        {% if author.getRole() %}
-                            <strong>{{ author.getRole() }}</strong>
-                            {% if author.getDescription() %}
-                                , {{ author.getDescription() }}
-                            {% endif %}
+                <h1 class="no-margin">{{ author.getName() }}</h1>
+                <p>
+                    {% if author.getRole() %}
+                        <strong>{{ author.getRole() }}</strong>
+                        {% if author.getDescription() %}
+                            , {{ author.getDescription() }}
                         {% endif %}
-                    </p>
-
-                    {% if postResult.getTotal() %}
-                        <p class="no-margin text--shout">
-                            <strong>
-                                {{ tr('blog_post_count_author', postResult.getTotal()) }}
-                            </strong>
-                        </p>
                     {% endif %}
-                </div>
+                </p>
+
+                {% if postResult.getTotal() %}
+                    <p class="no-margin text--shout">
+                        <strong>
+                            {{ tr('blog_post_count_author', postResult.getTotal()) }}
+                        </strong>
+                    </p>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This css class is no longer used, removed from template. Only other occurrence is in DatePicker, which is removed in [this PR](https://github.com/bbc/blogs-frontend/pull/69)