### PR TITLE
Blogs-1339 Semantic Markup

### DIFF
--- a/src/Ds/Author/AuthorSummary/author_summary.html.twig
+++ b/src/Ds/Author/AuthorSummary/author_summary.html.twig
@@ -10,9 +10,7 @@
             {% if author_summary.getAuthor().getRole() %}
                 <p class="no-margin br-page-text-ontext">{{ author_summary.getAuthor().getRole() }}</p>
             {% endif %}
-            {% if author_summary.getPostCount() is not null %}
-                <p class="no-margin">{{ tr('post', author_summary.getPostCount()) }}</p>
-            {% endif %}
+            <p class="no-margin">{{ tr('post', author_summary.getPostCount()) }}</p>
         </div>
     </div>
 </a>

--- a/src/Ds/Author/AuthorSummary/author_summary.html.twig
+++ b/src/Ds/Author/AuthorSummary/author_summary.html.twig
@@ -1,10 +1,10 @@
-<a itemprop="url" rel="author" href="{{ path('author_show', {blogId: author_summary.getBlogId(), guid: author_summary.getAuthor().getGuid()}) }}" data-istats-link-location="blogs_global_author">
+<a rel="author" href="{{ path('author_show', {blogId: author_summary.getBlogId(), guid: author_summary.getAuthor().getGuid()}) }}" data-istats-link-location="blogs_global_author">
     <div class="grid-wrapper">
         <div class="grid 1/3 1/1@bpw">
             {{- ds('image', author_summary.getAuthor().getImage(), 196, {770: 1/3, 1008: '196px'}) -}}
         </div>
         <div class="grid 2/3 1/1@bpw">
-            <h{{ author_summary.getOption('h_tag') }} class="gamma no-margin" itemprop="name">
+            <h{{ author_summary.getOption('h_tag') }} class="gamma no-margin">
                 {{ author_summary.getAuthor().getName() }}
             </h{{ author_summary.getOption('h_tag') }}>
             {% if author_summary.getAuthor().getRole() %}

--- a/src/Ds/Post/Author/author.html.twig
+++ b/src/Ds/Post/Author/author.html.twig
@@ -6,9 +6,9 @@
         </div>
         {% endif %}
 
-        <div class="media__body">
-            <p class="no-margin {{- author.getOption('is_slimline') ? '' : ' delta' -}}" itemprop="author">
-                {{- author.getName() -}}
+        <div class="media__body" itemprop="author" itemscope itemtype="http://schema.org/Person">
+            <p class="no-margin {{- author.getOption('is_slimline') ? '' : ' delta' -}}" >
+                <span itemprop="name">{{- author.getName() -}}</span>
 
                 {%- if author.getRole() -%}
                     {%- if author.getOption('is_slimline') %}, {% else %}</p><p class="no-margin">{% endif -%}

--- a/src/Ds/Post/Author/author.html.twig
+++ b/src/Ds/Post/Author/author.html.twig
@@ -6,9 +6,9 @@
         </div>
         {% endif %}
 
-        <div class="media__body" itemprop="author" itemscope itemtype="http://schema.org/Person">
+        <div class="media__body">
             <p class="no-margin {{- author.getOption('is_slimline') ? '' : ' delta' -}}" >
-                <span itemprop="name">{{- author.getName() -}}</span>
+                {{- author.getName() -}}
 
                 {%- if author.getRole() -%}
                     {%- if author.getOption('is_slimline') %}, {% else %}</p><p class="no-margin">{% endif -%}

--- a/src/Ds/Post/PostPreview/post_preview.html.twig
+++ b/src/Ds/Post/PostPreview/post_preview.html.twig
@@ -1,10 +1,10 @@
-<div itemprop="blogPost">
+<div>
     <h3 class="beta">
-        <a itemprop="url" href="{{ path('post', {blogId: post_preview.getBlogId(), guid: post_preview.getPost().getGuid()}) }}">
-            <span itemprop="name">{{ post_preview.getPost().getTitle() }}</span>
+        <a href="{{ path('post', {blogId: post_preview.getBlogId(), guid: post_preview.getPost().getGuid()}) }}">
+            {{ post_preview.getPost().getTitle() }}
         </a>
     </h3>
-    <p class="text--subtle milli no-margin" itemprop="datePublished">
+    <p class="text--subtle milli no-margin">
         <time datetime="{{ post_preview.getPost().getPublishedDate()|date(constant('DATE_ATOM')) }}">
             {{ post_preview.getPost().getPublishedDate()|local_date_intl('eeee dd MMMM yyyy, HH:mm') }}
         </time>

--- a/src/Ds/Post/PostSummary/post_summary.html.twig
+++ b/src/Ds/Post/PostSummary/post_summary.html.twig
@@ -1,14 +1,14 @@
-<div itemprop="blogPost">
+<div>
     <h{{ post_summary.getOption('h_tag') }} class="{{ post_summary.getOption('h_class') }} no-margin">
-        <a itemprop="url"
+        <a
             {% if post_summary.isFeaturedPost() %}
                 data-istats-link-location="blogs_featured_post"
             {% endif %}
            href="{{ path('post', {blogId: post_summary.getBlogId(), guid: post_summary.getPost().getGuid() }) }}">
-            <span itemprop="name">{{ post_summary.getPost.getTitle() }}</span>
+            {{ post_summary.getPost.getTitle() }}
         </a>
     </h{{ post_summary.getOption('h_tag') }}>
-    <p class="milli no-margin text--subtle" itemprop="datePublished">
+    <p class="milli no-margin text--subtle">
         <time datetime="{{ post_summary.getPost().getPublishedDate()|date(constant('DATE_ATOM')) }}">
             {{ post_summary.getPost().getPublishedDate()|local_date_intl('eeee dd MMMM yyyy, HH:mm') }}
         </time>
@@ -29,7 +29,7 @@
         {% endif %}
         <div class="media__body">
             {% if post_summary.getPost().getShortSynopsis() is not empty %}
-                <p itemprop="description">{{ post_summary.getPost().getShortSynopsis() }}</p>
+                <p>{{ post_summary.getPost().getShortSynopsis() }}</p>
             {% endif %}
             <p>
                 <a

--- a/src/Twig/SchemaJsonExtension.php
+++ b/src/Twig/SchemaJsonExtension.php
@@ -63,7 +63,7 @@ class SchemaJsonExtension extends Twig_Extension
         $schemaData['@context'] = 'http://schema.org';
 
         if (\count($this->schemaSnippets) == 1) {
-            return json_encode(array_merge($schemaData, $this->schemaSnippets));
+            return json_encode(array_merge($schemaData, $this->schemaSnippets[0]));
         }
 
         $schemaData['@graph'] = $this->schemaSnippets;

--- a/src/Twig/SchemaJsonExtension.php
+++ b/src/Twig/SchemaJsonExtension.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types = 1);
+namespace App\Twig;
+
+use App\BlogsService\Domain\Post;
+use Twig_Extension;
+use Twig_Function;
+
+class SchemaJsonExtension extends Twig_Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new Twig_Function('post_schema_data', [$this, 'generatePostSchemaData']),
+        ];
+    }
+
+    public function generatePostSchemaData(Post $post, string $postUrl): string
+    {
+        $schemaData['@context'] = 'http://schema.org';
+        $schemaData['@type'] = 'Article';
+        $schemaData['headline'] = $post->getTitle();
+        $schemaData['description'] = $post->getShortSynopsis();
+        $schemaData['image'] = $post->getImage()->getUrl(1200, 675);
+        $schemaData['datePublished'] = $post->getPublishedDate()->format('Y-m-d\TH:i:s');
+        $schemaData['dateModified'] = $post->getPublishedDate()->format('Y-m-d\TH:i:s');
+        $schemaData['author'] = [
+            '@type' => 'Person',
+            'name' => $post->getAuthor()->getName(),
+        ];
+        $schemaData['publisher'] = [
+            '@type' => 'Organization',
+            'name' => 'BBC',
+            'logo' => [
+                '@type' => 'ImageObject',
+                'url' => 'http://ichef.bbci.co.uk/images/ic/1200x675/p01tqv8z.png',
+            ],
+        ];
+        $schemaData['mainEntityOfPage'] = [
+            '@type' => 'WebPage',
+            '@id' => $postUrl,
+        ];
+
+        return json_encode($schemaData);
+    }
+}

--- a/templates/author/index.html.twig
+++ b/templates/author/index.html.twig
@@ -11,8 +11,9 @@
     {% endif %}
     {% if authors is defined %}
         {% if authors is empty %}
-            <br/>
-            <h1>{{ tr('no_results') }}</h1>
+            <div class="component">
+                <p>{{ tr('no_results') }}</p>
+            </div>
         {% else %}
             <div class="hidden visible@bpw component" aria-hidden="true">
                 <div class="grid-wrapper">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -72,6 +72,15 @@
 {% endif %}
 
 {{ build_script_snippets()|raw }}
+
+{# SCHEMA JSON #}
+{% set schema = generate_schema_json() %}
+{% if schema %}
+    <script type="application/ld+json">
+        {{- schema|raw -}}
+    </script>
+{% endif %}
+
 {{ branding.getBodyLast()|raw }}
 {{ orb.getBodylast()|raw }}
 </body>

--- a/templates/blog/show.html.twig
+++ b/templates/blog/show.html.twig
@@ -23,6 +23,9 @@
         {% set charLimit = 1200 %}
         <ul class="list-unstyled list-lined">
             {% for post in posts %}
+                {# SCHEMA.ORG JSON #}
+                {{ post_schema_data(post, url('post', {blogId: blog.getId(), guid: post.getGuid()})) }}
+
                 {#$keysForComments[] = $post->getForumId($this->blog);#}
                 {# for first three post character limit is 1200 #}
                 {# for the rest it is 600 #}

--- a/templates/blogs_base.html.twig
+++ b/templates/blogs_base.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    <div class="grid-wrapper">
+    <div class="grid-wrapper"{% block schema %}{% endblock %}>
         <div class="grid 2/3@bpw2 2/3@bpe">
             <div class="island br-box-page">
                 {% block content %}{% endblock %}

--- a/templates/blogs_base.html.twig
+++ b/templates/blogs_base.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    <div class="grid-wrapper"{% block schema %}{% endblock %}>
+    <div class="grid-wrapper">
         <div class="grid 2/3@bpw2 2/3@bpe">
             <div class="island br-box-page">
                 {% block content %}{% endblock %}

--- a/templates/post/show.html.twig
+++ b/templates/post/show.html.twig
@@ -5,7 +5,6 @@
 {% block title %}BBC {{ tr('page_title_blogs') }} - {{ blog.getName() }} - {{ post.getTitle() }}{% endblock %}
 
 {% block inline_head %}
-
     <script type="application/ld+json">
         {{- post_schema_data(post, url('post', {blogId: blog.getId(), guid: post.getGuid()}))|raw -}}
     </script>
@@ -163,7 +162,7 @@
             </h4>
             {%- if post.getPublishedDate() -%}
                 <p class="text--subtle milli">
-                    <time datetime="{{ post.getPublishedDate() | date('Y-m-d\TH:i:s') }}">{{ post.getPublishedDate() | date('l d F Y, H:i') }}</time>
+                    <time datetime="{{ post.getPublishedDate()|date(constant('DATE_ATOM')) }}">{{ post.getPublishedDate()|date('l d F Y, H:i') }}</time>
                 </p>
             {%- endif -%}
         </div>

--- a/templates/post/show.html.twig
+++ b/templates/post/show.html.twig
@@ -5,10 +5,6 @@
 {% block title %}BBC {{ tr('page_title_blogs') }} - {{ blog.getName() }} - {{ post.getTitle() }}{% endblock %}
 
 {% block inline_head %}
-    <script type="application/ld+json">
-        {{- post_schema_data(post, url('post', {blogId: blog.getId(), guid: post.getGuid()}))|raw -}}
-    </script>
-
     <meta property="og:type" content="article" />
     <meta name="twitter:card" content="summary">
 
@@ -146,6 +142,9 @@
             {{ script|raw }}
         {%- endfor -%}
     {%- endif -%}
+
+    {# SCHEMA JSON #}
+    {{- post_schema_data(post, url('post', {blogId: blog.getId(), guid: post.getGuid()})) -}}
 {%- endblock -%}
 
 {% macro morePosts(blogId, post, header, istatsLocation) %}

--- a/templates/post/show.html.twig
+++ b/templates/post/show.html.twig
@@ -6,12 +6,9 @@
 
 {% block inline_head %}
 
-    {# SCHEMA #}
-    {% set schema_data = {
-        '@context': 'http://schema.org',
-        '@type': 'BlogPosting',
-        'headline': post.getTitle() } %}
-
+    <script type="application/ld+json">
+        {{- post_schema_data(post, url('post', {blogId: blog.getId(), guid: post.getGuid()}))|raw -}}
+    </script>
 
     <meta property="og:type" content="article" />
     <meta name="twitter:card" content="summary">
@@ -27,20 +24,17 @@
     <meta property="og:site_name" content="{{ blog.getName() }}" />
 
     {# POST #}
-    <meta itemprop="name" content="{{ post.getTitle() }}">
     <meta name="twitter:title" content="{{ post.getTitle() }}">
     <meta property="og:title" content="{{ post.getTitle() }}" />
     <meta property="article:published_time" content="{{ post.getPublishedDate() | date(constant('DATE_W3C')) }}" />
     <meta property="og:url" content="{{ url('post', {blogId: blog.getId(), guid: post.getGuid()}) }}" />
 
     {%- if post.getShortSynopsis() -%}
-        <meta itemprop="description" content="{{ post.getShortSynopsis() }}">
         <meta name="twitter:description" content="{{ post.getShortSynopsis() }}">
         <meta property="og:description" content="{{ post.getShortSynopsis() }}" />
     {%- endif -%}
 
     {%- if post.getImage() -%}
-        <meta itemprop="image" content="{{ post.getImage().getUrl(1200,675) }}">
         <meta property="og:image" content="{{ post.getImage().getUrl(1200,675) }}" />
     {%- endif -%}
 
@@ -66,8 +60,6 @@
 
     {{ parent() }}
 {% endblock %}
-
-{% block schema %} itemscope itemtype="http://schema.org/BlogPosting"{% endblock %}
 
 {%- block content -%}
     <div class="islet br-box-subtle component text--right">
@@ -99,9 +91,9 @@
     <div class="component component--lined br-keyline">
         <article>
             <div class="component component--lined br-keyline">
-                <h1 itemprop="name headline">{{ post.getTitle() }}</h1>
+                <h1>{{ post.getTitle() }}</h1>
 
-                <p class="text--subtle milli" itemprop="datePublished dateModified"><time datetime="{{ post.getPublishedDate()|date(constant('DATE_ATOM')) }}">
+                <p class="text--subtle milli"><time datetime="{{ post.getPublishedDate()|date(constant('DATE_ATOM')) }}">
                     {{ post.getPublishedDate()|date('l d F Y, H:i') }}
                 </time></p>
 
@@ -166,7 +158,7 @@
             <h4 class="delta no-margin">
                 <a data-istats-link-location="{{ istatsLocation }}"
                    href="{{ path('post', {blogId: blogId, guid: post.getGuid() }) }}">
-                    <span itemprop="name">{{ post.getTitle() }}</span>
+                    {{ post.getTitle() }}
                 </a>
             </h4>
             {%- if post.getPublishedDate() -%}

--- a/templates/post/show.html.twig
+++ b/templates/post/show.html.twig
@@ -5,6 +5,14 @@
 {% block title %}BBC {{ tr('page_title_blogs') }} - {{ blog.getName() }} - {{ post.getTitle() }}{% endblock %}
 
 {% block inline_head %}
+
+    {# SCHEMA #}
+    {% set schema_data = {
+        '@context': 'http://schema.org',
+        '@type': 'BlogPosting',
+        'headline': post.getTitle() } %}
+
+
     <meta property="og:type" content="article" />
     <meta name="twitter:card" content="summary">
 
@@ -59,6 +67,8 @@
     {{ parent() }}
 {% endblock %}
 
+{% block schema %} itemscope itemtype="http://schema.org/BlogPosting"{% endblock %}
+
 {%- block content -%}
     <div class="islet br-box-subtle component text--right">
         <ul class="list-unstyled list--piped">
@@ -87,11 +97,11 @@
     </div>
 
     <div class="component component--lined br-keyline">
-        <article itemscope itemtype="http://schema.org/blogPost">
+        <article>
             <div class="component component--lined br-keyline">
-                <h1 itemprop="name">{{ post.getTitle() }}</h1>
+                <h1 itemprop="name headline">{{ post.getTitle() }}</h1>
 
-                <p class="text--subtle milli" itemprop="datePublished"><time datetime="{{ post.getPublishedDate()|date(constant('DATE_ATOM')) }}">
+                <p class="text--subtle milli" itemprop="datePublished dateModified"><time datetime="{{ post.getPublishedDate()|date(constant('DATE_ATOM')) }}">
                     {{ post.getPublishedDate()|date('l d F Y, H:i') }}
                 </time></p>
 
@@ -154,13 +164,13 @@
         </div>
         <div class="grid 2/3@bpw2 2/3@bpe">
             <h4 class="delta no-margin">
-                <a data-istats-link-location="{{ istatsLocation }}" itemprop="url"
+                <a data-istats-link-location="{{ istatsLocation }}"
                    href="{{ path('post', {blogId: blogId, guid: post.getGuid() }) }}">
                     <span itemprop="name">{{ post.getTitle() }}</span>
                 </a>
             </h4>
             {%- if post.getPublishedDate() -%}
-                <p class="text--subtle milli" itemprop="datePublished">
+                <p class="text--subtle milli">
                     <time datetime="{{ post.getPublishedDate() | date('Y-m-d\TH:i:s') }}">{{ post.getPublishedDate() | date('l d F Y, H:i') }}</time>
                 </p>
             {%- endif -%}

--- a/templates/post/show.html.twig
+++ b/templates/post/show.html.twig
@@ -87,7 +87,7 @@
     </div>
 
     <div class="component component--lined br-keyline">
-        <article itemprop="blogPost">
+        <article itemscope itemtype="http://schema.org/blogPost">
             <div class="component component--lined br-keyline">
                 <h1 itemprop="name">{{ post.getTitle() }}</h1>
 

--- a/templates/tag/show.html.twig
+++ b/templates/tag/show.html.twig
@@ -13,7 +13,7 @@
     </div>
 
     <div class="component">
-        <h2>{{ tr('header_posts') }} ({{ postResults.total }})</h2>
+        <h2>{{ tr('header_posts') }} ({{ postResults.getTotal() }})</h2>
         {% if postResults.getDomainModels() is empty %}
             <p>{{ tr('no_results') }}</p>
         {% else %}

--- a/tests/Controller/AuthorIndexControllerTest.php
+++ b/tests/Controller/AuthorIndexControllerTest.php
@@ -80,7 +80,7 @@ class AuthorIndexControllerTest extends BaseWebTestCase
     public function testBlogWithNoAuthors()
     {
         $crawler = $this->getCrawlerForPage([], []);
-        $this->assertEquals('There are no results', $crawler->filterXPath('//h1')->last()->text());
+        $this->assertEquals('There are no results', $crawler->filterXPath('//p')->first()->text());
     }
 
     /**

--- a/tests/Controller/PostByDateControllerTest.php
+++ b/tests/Controller/PostByDateControllerTest.php
@@ -96,7 +96,7 @@ class PostByDateControllerTest extends BaseWebTestCase
         $september = $datePickerMonths->last()->previousAll()->previousAll()->previousAll();
         $this->assertEquals('September (1)', trim($september->text()));
 
-        $blogPosts = $crawler->filterXPath('//div[@itemprop="blogPost"]');
+        $blogPosts = $crawler->filterXPath('//li[@class="br-keyline"]');
         $this->assertEquals(1, $blogPosts->count());
 
         $firstPostDate = $blogPosts->first()->filterXPath('//time')->text();
@@ -180,7 +180,7 @@ class PostByDateControllerTest extends BaseWebTestCase
         $december = $datePickerMonths->last();
         $this->assertEquals('December (4)', trim($december->text()));
 
-        $blogPosts = $crawler->filterXPath('//div[@itemprop="blogPost"]');
+        $blogPosts = $crawler->filterXPath('//li[@class="br-keyline"]');
         $this->assertEquals(3, $blogPosts->count());
 
         $firstPostDate = $blogPosts->first()->filterXPath('//time')->text();

--- a/tests/Twig/SchemaJsonExtensionTest.php
+++ b/tests/Twig/SchemaJsonExtensionTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App\Twig;
+
+use App\Twig\SchemaJsonExtension;
+use PHPUnit\Framework\TestCase;
+use Tests\App\Builders\PostBuilder;
+
+class SchemaJsonExtensionTest extends TestCase
+{
+    /** @var SchemaJsonExtension */
+    private $extension;
+
+    public function setUp()
+    {
+        $this->extension = new SchemaJsonExtension();
+    }
+
+    public function testNoSchemaElements()
+    {
+        $result = $this->extension->generateSchemaData();
+        $this->assertEquals('', $result);
+    }
+
+    public function testSingleSchemaElement()
+    {
+        $post = PostBuilder::default()->build();
+        $this->extension->generatePostSchemaData($post, 'someurl');
+
+        $result = $this->extension->generateSchemaData();
+
+        $this->assertJson($result);
+        $this->assertJsonKeyNotExists($result, '@graph');
+    }
+
+    public function testMultipleSchemaElements()
+    {
+        $post = PostBuilder::default()->build();
+        $this->extension->generatePostSchemaData($post, 'someurl');
+        $this->extension->generatePostSchemaData($post, 'someotherurl');
+
+        $result = $this->extension->generateSchemaData();
+
+        $this->assertJson($result);
+        $this->assertJsonKeyExists($result, '@graph');
+    }
+
+
+    private function assertJsonKeyExists(string $json, string $key)
+    {
+        $this->assertJsonKeyExistance($json, $key, true);
+    }
+
+    private function assertJsonKeyNotExists(string $json, string $key)
+    {
+        $this->assertJsonKeyExistance($json, $key, false);
+    }
+
+    private function assertJsonKeyExistance(string $json, string $key, bool $doesExist)
+    {
+        $jsonObject = json_decode($json, true);
+        $doesExist ? $this->assertArrayHasKey($key, $jsonObject) : $this->assertArrayNotHasKey($key, $jsonObject);
+    }
+}


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/BLOGS-1339

- A few minor tweaks so the markup is sensible e.g. the `<h1>` example in the ticket
- Also fixed the Schema.org tags for the Homepage and Post Show - others were incomplete and have been removed as they're invalid markup in those places