### PR TITLE
Speedup build tests

### DIFF
--- a/bin/ci-docker
+++ b/bin/ci-docker
@@ -33,7 +33,13 @@ php --version
 yarn gulp-ci
 
 # Run PHPUnit
-bin/phpunit || RESULT=1
+if $WITH_TEST_COVERAGE ; then
+    echo "Code coverage: on"
+    bin/phpunit || RESULT=1
+else
+    echo "Code coverage: off"
+    bin/phpunit --no-coverage || RESULT=1
+fi
 
 # Run PHPCS
 vendor/bin/phpcs -n --report=checkstyle --report-file=build/reports/checkstyle.xml || RESULT=1

--- a/bin/ci-jenkins
+++ b/bin/ci-jenkins
@@ -4,6 +4,7 @@ function docker_run {
     docker run --rm \
     -u `id -u`:`id -g` \
     -e OAUTH="$OAUTH_TOKEN" \
+    -e WITH_TEST_COVERAGE="$WITH_TEST_COVERAGE" \
     -v "$WORKSPACE":/mnt/ \
     -v /etc/pki/tls/private/client.key:/etc/pki/tls/private/client.key \
     -v /etc/pki/tls/certs/client.crt:/etc/pki/tls/certs/client.crt \

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.0",
+        "johnkary/phpunit-speedtrap": "^2.0",
         "phpstan/phpstan": "^0.9",
         "phpstan/phpstan-phpunit": "^0.9",
         "squizlabs/php_codesniffer": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "38bf38fd40fd598655f8e6a582ebabbb",
+    "content-hash": "aedcdcbfb77f702fe5638a03e47afd88",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -3356,6 +3356,54 @@
                 "package versions"
             ],
             "time": "2017-11-30T22:02:29+00:00"
+        },
+        {
+            "name": "johnkary/phpunit-speedtrap",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnkary/phpunit-speedtrap.git",
+                "reference": "a1e39e0e3d07e0faee4ef3f342229d68fab07b5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/a1e39e0e3d07e0faee4ef3f342229d68fab07b5f",
+                "reference": "a1e39e0e3d07e0faee4ef3f342229d68fab07b5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JohnKary\\PHPUnit\\Listener\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Kary",
+                    "email": "john@johnkary.net"
+                }
+            ],
+            "description": "Find slow tests in your PHPUnit test suite",
+            "homepage": "https://github.com/johnkary/phpunit-speedtrap",
+            "keywords": [
+                "phpunit",
+                "profile",
+                "slow"
+            ],
+            "time": "2017-12-06T15:14:00+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -43,6 +43,10 @@
         </whitelist>
     </filter>
 
+    <listeners>
+        <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+    </listeners>
+
     <logging>
         <log type="junit" target="./build/reports/test-results.xml" logIncompleteSkipped="true"/>
         <log type="coverage-html" target="./build/reports/coverage" charset="UTF-8"

--- a/symfony.lock
+++ b/symfony.lock
@@ -71,6 +71,9 @@
     "jean85/pretty-package-versions": {
         "version": "1.0.3"
     },
+    "johnkary/phpunit-speedtrap": {
+        "version": "v2.0.0"
+    },
     "monolog/monolog": {
         "version": "1.23.0"
     },


### PR DESCRIPTION
As per [PROGRAMMES-6154](https://github.com/bbc/programmes-frontend/pull/398/files) have made code coverage reports optional. 
Have tested, and reduces test time from ~45 seconds to ~5 seconds. 
Have also added SpeedTrap as per [this PR](https://github.com/bbc/programmes-frontend/pull/379) to identify slow tests.