### PR TITLE
Gracefully handle empty ClipsBlock

### DIFF
--- a/src/BlogsService/Mapper/IsiteToDomain/ContentBlockMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/ContentBlockMapper.php
@@ -32,18 +32,23 @@ class ContentBlockMapper extends Mapper
                 );
                 break;
             case 'code':
-                $contentBlockData   = $form->content;
+                $contentBlockData = $form->content;
                 $contentBlock = new Code(
                     $this->getString($contentBlockData->code)
                 );
                 break;
             case 'clips':
-                $contentBlockData   = $form->content;
+                $contentBlockData = $form->content;
 
-                $url            = $this->getString($contentBlockData->url);
-                $id             = $this->getString($contentBlockData->id);
-                $playlistType   = $this->getPlaylistType($id, $url);
-                $caption        = $this->getString($contentBlockData->caption);
+                $url = $this->getString($contentBlockData->url);
+                $id = $this->getString($contentBlockData->id);
+                $playlistType = $this->getPlaylistType($id, $url);
+                $caption = $this->getString($contentBlockData->caption);
+
+                // if this doesn't exist, then the clip hasn't been defined in iSite properly
+                if (\is_null($playlistType)) {
+                    return null;
+                }
 
                 $contentBlock = new Clips(
                     $id,
@@ -53,14 +58,14 @@ class ContentBlockMapper extends Mapper
                 );
                 break;
             case 'image':
-                $contentBlockData   = $form->content;
+                $contentBlockData = $form->content;
                 $contentBlock = new Image(
                     $this->getImageIfExists($contentBlockData->image),
                     $this->getString($contentBlockData->caption)
                 );
                 break;
             case 'social':
-                $contentBlockData   = $form->content;
+                $contentBlockData = $form->content;
                 $contentBlock = new Social(
                     $this->getString($contentBlockData->link),
                     $this->getString($contentBlockData->alt)

--- a/tests/BlogsService/Mapper/IsiteToDomain/PostMapperTest.php
+++ b/tests/BlogsService/Mapper/IsiteToDomain/PostMapperTest.php
@@ -34,9 +34,11 @@ class PostMapperTest extends TestCase
         );
     }
 
-    public function testIgnoresInvalidContentBlocks()
+    /**
+     * @dataProvider invalidContentBlockProvider
+     */
+    public function testIgnoresInvalidContentBlocks(string $type)
     {
-        $type = 'post_invalidcontentblocks.xml';
         $basePath = __DIR__ . '/../../../mock_data/';
 
         $xml = file_get_contents($basePath . $type);
@@ -58,5 +60,14 @@ class PostMapperTest extends TestCase
         $this->assertInstanceOf(Post::class, $domainModel);
 
         $this->assertNotContains(null, $domainModel->getContent());
+    }
+
+    public function invalidContentBlockProvider(): array
+    {
+        return [
+            'generallyInvalid' => ['type' => 'post_invalidcontentblocks.xml'],
+            'invalidSmps' => ['type' => 'post_invalidsmp.xml'],
+
+        ];
     }
 }

--- a/tests/BlogsService/Mapper/IsiteToDomain/PostMapperTest.php
+++ b/tests/BlogsService/Mapper/IsiteToDomain/PostMapperTest.php
@@ -67,7 +67,6 @@ class PostMapperTest extends TestCase
         return [
             'generallyInvalid' => ['type' => 'post_invalidcontentblocks.xml'],
             'invalidSmps' => ['type' => 'post_invalidsmp.xml'],
-
         ];
     }
 }

--- a/tests/mock_data/post_invalidsmp.xml
+++ b/tests/mock_data/post_invalidsmp.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result xmlns="https://production.bbc.co.uk/isite2/contentreader/xml/result">
+    <metadata>
+        <modifiedDateTime>2111-11-24T11:11:01.111111Z</modifiedDateTime>
+        <creationDateTime>2111-11-24T11:11:01.111111Z</creationDateTime>
+        <type>blogs-post</type>
+        <fileId>blogs-post-2222222</fileId>
+        <guid>a3aa3aa3-33aa-3a3a-33a3-aaa3333a3333</guid>
+    </metadata>
+    <document>
+        <form xmlns="https://production.bbc.co.uk/isite2/project/blogs-aboutthebbc/blogs-post">
+            <metadata>
+                <published-date>2111-11-24T11:11:01.111111Z</published-date>
+                <title>Blog title</title>
+                <short-synopsis>Some synopsis</short-synopsis>
+                <author></author>
+                <post-image>p11aa111</post-image>
+                <file_id>1111111111</file_id>
+            </metadata>
+            <content>
+                <repeater>
+                    <blog-post-content>
+                        <result xmlns="https://production.bbc.co.uk/isite2/contentreader/xml/result">
+                            <metadata>
+                                <modifiedDateTime>2111-11-24T11:11:01.111111Z</modifiedDateTime>
+                                <creationDateTime>2111-11-24T11:11:01.111111Z</creationDateTime>
+                                <type>blogs-content-clips</type>
+                                <fileId>blogs-content-name</fileId>
+                                <guid>a3aa3aa3-33aa-3a3a-33a3-aaa3333a3333</guid>
+                            </metadata>
+                            <document>
+                                <form
+                                    xmlns="https://production.bbc.co.uk/isite2/project/blogs-aboutthebbc/blogs-content-clips">
+                                    <metadata>
+                                        <name>some_name</name>
+                                        <file_id>1111111111</file_id>
+                                    </metadata>
+                                    <content>
+                                        <id/>
+                                        <url/>
+                                        <hintbox-readonly/>
+                                        <caption/>
+                                    </content>
+                                </form>
+                            </document>
+                        </result>
+                    </blog-post-content>
+                </repeater>
+                <repeater>
+                    <blog-post-content>
+                        <result xmlns="https://production.bbc.co.uk/isite2/contentreader/xml/result">
+                            <metadata>
+                                <modifiedDateTime>2111-11-24T11:11:01.111111Z</modifiedDateTime>
+                                <creationDateTime>2111-11-24T11:11:01.111111Z</creationDateTime>
+                                <type>blogs-content-prose</type>
+                                <fileId>blogs-content-1111111111</fileId>
+                                <guid>a3aa3aa3-33aa-3a3a-33a3-aaa3333a3333</guid>
+                            </metadata>
+                            <document>
+                                <form
+                                    xmlns="https://production.bbc.co.uk/isite2/project/blogs-aboutthebbc/blogs-content-prose">
+                                    <metadata>
+                                        <name>somename</name>
+                                        <file_id>1111111111</file_id>
+                                    </metadata>
+                                    <content>
+                                        <prose>here is some prose</prose>
+                                    </content>
+                                </form>
+                            </document>
+                        </result>
+                    </blog-post-content>
+                </repeater>
+            </content>
+            <Tags/>
+        </form>
+    </document>
+</result>


### PR DESCRIPTION
So, here's the thing. It seems it _is_ possible for an empty ClipsBlock to be defined and published, so we need to validate as we're mapping it. 

For an example, head to: /blogs/aboutthebbc/entries/87e83282-cd45-40f5-bf80-e764de7ce6e1