### PR TITLE
Fix null branding, bbc_site

### DIFF
--- a/src/BlogsService/Domain/Blog.php
+++ b/src/BlogsService/Domain/Blog.php
@@ -63,7 +63,7 @@ class Blog
         bool $showImageInDescription,
         string $language,
         string $istatsCountername,
-        ?string $bbcSite,
+        string $bbcSite,
         string $brandingId,
         array $modules,
         Social $social,

--- a/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
@@ -38,7 +38,7 @@ class BlogMapper extends Mapper
 
         $hasCommentsEnabled = ($this->getString($formMetaData->{'site-id-comments'}) ?? '') !== '';
 
-        $bbcSite = $this->getString($formMetaData->{'bbc-site'});
+        $bbcSite = $this->getString($formMetaData->{'bbc-site'}) ?? '';
         $brandingId = $this->getString($formMetaData->{'blogs-branding-id'});
 
         $featuredPost = null;

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -116,7 +116,9 @@ abstract class BaseController extends AbstractController
 
     protected function setBrandingId(string $brandingId)
     {
-        $this->brandingId = $brandingId;
+        if ($brandingId) {
+            $this->brandingId = $brandingId;
+        }
     }
 
     protected function setLocale(string $locale)


### PR DESCRIPTION
A couple of fixes for things picked up during load tests:
 - We were calling `.../branding/live/projects/.json` when no branding was set, before falling back to default
 - Null `bbc_site` value was causing a return type error as it's not a string 