### PR TITLE
BLOGS-1332 Loadtest Tweaks

### DIFF
--- a/config/packages/prod/csa_guzzle.yaml
+++ b/config/packages/prod/csa_guzzle.yaml
@@ -5,5 +5,5 @@ csa_guzzle:
                 cert: '/etc/pki/tls/certs/client.crt'
                 ssl_key: '/etc/pki/tls/private/client.key'
                 verify: false
-                timeout: 60
-                connect_timeout: 5
+                timeout: 20
+                connect_timeout: 8

--- a/project.json
+++ b/project.json
@@ -18,7 +18,7 @@
             "front_controller": "index.php",
 
             "opcache.max_accelerated_files": 20000,
-            "opcache.memory_consumption": 256,
+            "opcache.memory_consumption": 128,
             "opcache.interned_strings_buffer": 16,
             "memory_limit": "128m",
             "max_execution_time": 30,

--- a/project.json
+++ b/project.json
@@ -17,8 +17,8 @@
             "comment": "We're targeting c4.xlarge instances",
             "front_controller": "index.php",
 
-            "opcache.max_accelerated_files": 7963,
-            "opcache.memory_consumption": 64,
+            "opcache.max_accelerated_files": 20000,
+            "opcache.memory_consumption": 256,
             "opcache.interned_strings_buffer": 16,
             "memory_limit": "128m",
             "max_execution_time": 30,

--- a/project.json
+++ b/project.json
@@ -37,7 +37,8 @@
             "nginx.gzip_experimental_config": true,
             "nginx.force_http_to_https_redirect": true,
             "nginx.remove_trailing_slashes": true,
-            "nginx.redirect_cache_max_age": 3600
+            "nginx.redirect_cache_max_age": 3600,
+            "nginx.fastcgi_buffers": "500 4k"
         }
     }
 }

--- a/project.json
+++ b/project.json
@@ -24,7 +24,7 @@
             "max_execution_time": 30,
             "fpm.mode": "dynamic",
             "fpm.process_idle_timeout": "10s",
-            "fpm.max_children": 162,
+            "fpm.max_children": 60,
             "fpm.start_servers": 32,
             "fpm.min_spare_servers": 22,
             "fpm.max_spare_servers": 42,

--- a/src/BlogsService/Domain/Blog.php
+++ b/src/BlogsService/Domain/Blog.php
@@ -72,11 +72,11 @@ class Blog
         Image $image,
         bool $isArchived = false
     ) {
-        if (!is_bool($showImageInDescription)) {
+        if (!\is_bool($showImageInDescription)) {
             throw new InvalidArgumentException('showImageInDescription must be of type boolean');
         }
 
-        if (!is_bool($isArchived)) {
+        if (!\is_bool($isArchived)) {
             throw new InvalidArgumentException('isArchived must be of type boolean');
         }
 

--- a/src/BlogsService/Infrastructure/MapperFactory.php
+++ b/src/BlogsService/Infrastructure/MapperFactory.php
@@ -10,10 +10,18 @@ use App\BlogsService\Mapper\IsiteToDomain\Mapper;
 use App\BlogsService\Mapper\IsiteToDomain\ModuleMapper;
 use App\BlogsService\Mapper\IsiteToDomain\PostMapper;
 use App\BlogsService\Mapper\IsiteToDomain\TagMapper;
+use Psr\Log\LoggerInterface;
 
 class MapperFactory
 {
     protected $instances = [];
+
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
 
     public function createPostMapper(): PostMapper
     {
@@ -48,7 +56,7 @@ class MapperFactory
     private function findMapper(string $mapperType): Mapper
     {
         if (!isset($this->instances[$mapperType])) {
-            $this->instances[$mapperType] = new $mapperType($this);
+            $this->instances[$mapperType] = new $mapperType($this, $this->logger);
         }
         return $this->instances[$mapperType];
     }

--- a/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
@@ -58,6 +58,8 @@ class BlogMapper extends Mapper
                     );
                 }
             } catch (PostMappingException $e) {
+                // We're not doing anything here because in reality, this will only occur if a featured post
+                // is subsequently unpublished, in which case we shouldn't display it or break the page
             }
         }
 

--- a/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
@@ -6,7 +6,7 @@ namespace App\BlogsService\Mapper\IsiteToDomain;
 use App\BlogsService\Domain\Blog;
 use App\BlogsService\Domain\ValueObject\Comments;
 use App\BlogsService\Domain\ValueObject\Social;
-use App\Exception\CouldNotMapPostException;
+use App\Exception\PostMappingException;
 use SimpleXMLElement;
 
 class BlogMapper extends Mapper
@@ -57,7 +57,7 @@ class BlogMapper extends Mapper
                         $form->{'section-9'}->featured->result
                     );
                 }
-            } catch (CouldNotMapPostException $e) {
+            } catch (PostMappingException $e) {
             }
         }
 

--- a/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
@@ -6,6 +6,7 @@ namespace App\BlogsService\Mapper\IsiteToDomain;
 use App\BlogsService\Domain\Blog;
 use App\BlogsService\Domain\ValueObject\Comments;
 use App\BlogsService\Domain\ValueObject\Social;
+use App\Exception\CouldNotMapPostException;
 use SimpleXMLElement;
 
 class BlogMapper extends Mapper
@@ -45,15 +46,18 @@ class BlogMapper extends Mapper
 
         // Check is there is a featured post
         if (!empty($form->{'section-9'}->featured)) {
-            $postMetadata = $form
-                ->{'section-9'}
-                ->{'featured'}
-                ->result
-                ->metadata;
-            if (!\is_null($postMetadata)) {
-                $featuredPost = $this->mapperFactory->createPostMapper()->getDomainModel(
-                    $form->{'section-9'}->featured->result
-                );
+            try {
+                $postMetadata = $form
+                    ->{'section-9'}
+                    ->{'featured'}
+                    ->result
+                    ->metadata;
+                if (!\is_null($postMetadata)) {
+                    $featuredPost = $this->mapperFactory->createPostMapper()->getDomainModel(
+                        $form->{'section-9'}->featured->result
+                    );
+                }
+            } catch (CouldNotMapPostException $e) {
             }
         }
 

--- a/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/BlogMapper.php
@@ -50,7 +50,7 @@ class BlogMapper extends Mapper
                 ->{'featured'}
                 ->result
                 ->metadata;
-            if (!is_null($postMetadata)) {
+            if (!\is_null($postMetadata)) {
                 $featuredPost = $this->mapperFactory->createPostMapper()->getDomainModel(
                     $form->{'section-9'}->featured->result
                 );
@@ -64,7 +64,7 @@ class BlogMapper extends Mapper
 
             foreach ($moduleContent as $module) {
                 $moduleMetadata = $module->{'module'}->result->metadata;
-                if (!is_null($moduleMetadata)) {
+                if (!\is_null($moduleMetadata)) {
                     $modules[] = $this->mapperFactory->createModuleMapper()->getDomainModel(
                         $module->{'module'}->result
                     );
@@ -102,7 +102,7 @@ class BlogMapper extends Mapper
         $namespaces = $form->getNamespaces();
         $projectNameSpace = reset($namespaces);
         $projectNameSpaceParts = explode('/', $projectNameSpace);
-        $id = $projectNameSpaceParts[count($projectNameSpaceParts) - 2];
+        $id = $projectNameSpaceParts[\count($projectNameSpaceParts) - 2];
 
         return $id;
     }

--- a/src/BlogsService/Mapper/IsiteToDomain/ContentBlockMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/ContentBlockMapper.php
@@ -8,7 +8,8 @@ use App\BlogsService\Domain\ContentBlock\Code;
 use App\BlogsService\Domain\ContentBlock\Image;
 use App\BlogsService\Domain\ContentBlock\Prose;
 use App\BlogsService\Domain\ContentBlock\Social;
-use App\Exception\InvalidContentBlockException;
+use App\BlogsService\Infrastructure\MapperFactory;
+use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 class ContentBlockMapper extends Mapper
@@ -72,7 +73,8 @@ class ContentBlockMapper extends Mapper
                 );
                 break;
             default:
-                throw new InvalidContentBlockException('Could not map invalid Content Block type.');
+                $this->logger->error('Invalid post content block type. Found ' . $type);
+                break;
         }
 
         return $contentBlock;

--- a/src/BlogsService/Mapper/IsiteToDomain/Mapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/Mapper.php
@@ -6,6 +6,7 @@ namespace App\BlogsService\Mapper\IsiteToDomain;
 use App\BlogsService\Domain\Image;
 use App\BlogsService\Infrastructure\MapperFactory;
 use Cake\Chronos\Chronos;
+use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 /**
@@ -18,9 +19,12 @@ abstract class Mapper
 {
     protected $mapperFactory;
 
-    public function __construct(MapperFactory $mapperFactory)
+    protected $logger;
+
+    public function __construct(MapperFactory $mapperFactory, LoggerInterface $logger)
     {
         $this->mapperFactory = $mapperFactory;
+        $this->logger = $logger;
     }
 
     abstract public function getDomainModel(SimpleXMLElement $isiteObject);

--- a/src/BlogsService/Mapper/IsiteToDomain/PostMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/PostMapper.php
@@ -5,7 +5,7 @@ namespace App\BlogsService\Mapper\IsiteToDomain;
 
 use App\BlogsService\Domain\Post;
 use App\BlogsService\Domain\ValueObject\GUID;
-use App\Exception\CouldNotMapPostException;
+use App\Exception\PostMappingException;
 use SimpleXMLElement;
 
 class PostMapper extends Mapper
@@ -27,7 +27,7 @@ class PostMapper extends Mapper
             $title = $this->getString($formMetaData->{'title'});
             $shortSynopsis = $this->getString($formMetaData->{'short-synopsis'});
         } else {
-            throw new CouldNotMapPostException();
+            throw new PostMappingException('Could not map post');
         }
 
         $author = null;

--- a/src/BlogsService/Mapper/IsiteToDomain/PostMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/PostMapper.php
@@ -5,7 +5,7 @@ namespace App\BlogsService\Mapper\IsiteToDomain;
 
 use App\BlogsService\Domain\Post;
 use App\BlogsService\Domain\ValueObject\GUID;
-use Exception;
+use App\Exception\CouldNotMapPostException;
 use SimpleXMLElement;
 
 class PostMapper extends Mapper
@@ -15,76 +15,76 @@ class PostMapper extends Mapper
         if (!isset($isiteObject->document)) {
             return null;
         }
-        try {
-            $formMetaData = $this->getFormMetaData($isiteObject);
-            $form = $this->getForm($isiteObject);
-            $guid = $this->getString($this->getMetaData($isiteObject)->guid);
 
-            $forumId = str_replace('-', '_', '_' . $guid);
+        $formMetaData = $this->getFormMetaData($isiteObject);
+        $form = $this->getForm($isiteObject);
+        $guid = $this->getString($this->getMetaData($isiteObject)->guid);
 
+        $forumId = str_replace('-', '_', '_' . $guid);
+
+        if (isset($formMetaData->{'published-date'}) && isset($formMetaData->{'title'}) && isset($formMetaData->{'short-synopsis'})) {
             $publishedDate = $this->getDateTime($formMetaData->{'published-date'});
             $title = $this->getString($formMetaData->{'title'});
             $shortSynopsis = $this->getString($formMetaData->{'short-synopsis'});
+        } else {
+            throw new CouldNotMapPostException();
+        }
 
-            $author = null;
+        $author = null;
+        $authorMetadata = $formMetaData
+            ->{'author'}
+            ->result
+            ->metadata;
+        if (\is_object($authorMetadata)) {
+            $authorGUID = (string) $authorMetadata->{'guid'};
 
-            $authorMetadata = $formMetaData
-                ->{'author'}
-                ->result
-                ->metadata;
-            if (\is_object($authorMetadata)) {
-                $authorGUID = (string) $authorMetadata->{'guid'};
+            if (!empty($authorGUID)) {
+                $author = $this->mapperFactory->createAuthorsMapper()->getDomainModel(
+                    $formMetaData->{'author'}->result
+                );
+            }
+        }
 
-                if (!empty($authorGUID)) {
-                    $author = $this->mapperFactory->createAuthorsMapper()->getDomainModel(
-                        $formMetaData->{'author'}->result
+        $image = $this->getImageIfExists($formMetaData->{'post-image'});
+
+        $contentBlocks = [];
+        $contentBlockContent = $form->content->xpath("./*");
+
+        $contentBlockMapper = $this->mapperFactory->createContentBlockMapper();
+
+        foreach ($contentBlockContent as $contentBlock) {
+            $result = $contentBlock->{'blog-post-content'}->result;
+
+            if (\is_object($result->metadata) && $contentBlockMapper->getDomainModel($result)) {
+                $contentBlocks[] = $contentBlockMapper->getDomainModel($result);
+            }
+        }
+        $tags = [];
+        $tagContent = $form->{'Tags'}->{'tag-content'};
+
+        foreach ($tagContent as $tag) {
+            if (isset($tag->{'tag'}->result->document)) {
+                $tagMetadata = $tag->{'tag'}->result->metadata;
+                $formMetaData = $this->getFormMetaData($tag->{'tag'}->result);
+
+                if (\is_object($formMetaData) && !\is_null($tagMetadata)) {
+                    $tags[] = $this->mapperFactory->createTagMapper()->getDomainModel(
+                        $tag->{'tag'}->result
                     );
                 }
             }
-
-            $image = $this->getImageIfExists($formMetaData->{'post-image'});
-
-            $contentBlocks = [];
-            $contentBlockContent = $form->content->xpath("./*");
-
-            $contentBlockMapper = $this->mapperFactory->createContentBlockMapper();
-
-            foreach ($contentBlockContent as $contentBlock) {
-                $result = $contentBlock->{'blog-post-content'}->result;
-
-                if (\is_object($result->metadata) && $contentBlockMapper->getDomainModel($result)) {
-                    $contentBlocks[] = $contentBlockMapper->getDomainModel($result);
-                }
-            }
-            $tags = [];
-            $tagContent = $form->{'Tags'}->{'tag-content'};
-
-            foreach ($tagContent as $tag) {
-                if (isset($tag->{'tag'}->result->document)) {
-                    $tagMetadata = $tag->{'tag'}->result->metadata;
-                    $formMetaData = $this->getFormMetaData($tag->{'tag'}->result);
-
-                    if (\is_object($formMetaData) && !\is_null($tagMetadata)) {
-                        $tags[] = $this->mapperFactory->createTagMapper()->getDomainModel(
-                            $tag->{'tag'}->result
-                        );
-                    }
-                }
-            }
-
-            return new Post(
-                new GUID($guid),
-                $forumId,
-                $publishedDate,
-                $title,
-                $shortSynopsis,
-                $author,
-                $image,
-                $contentBlocks,
-                $tags
-            );
-        } catch (Exception $e) {
-            return null;
         }
+
+        return new Post(
+            new GUID($guid),
+            $forumId,
+            $publishedDate,
+            $title,
+            $shortSynopsis,
+            $author,
+            $image,
+            $contentBlocks,
+            $tags
+        );
     }
 }

--- a/src/BlogsService/Mapper/IsiteToDomain/PostMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/PostMapper.php
@@ -32,7 +32,7 @@ class PostMapper extends Mapper
                 ->{'author'}
                 ->result
                 ->metadata;
-            if (is_object($authorMetadata)) {
+            if (\is_object($authorMetadata)) {
                 $authorGUID = (string) $authorMetadata->{'guid'};
 
                 if (!empty($authorGUID)) {
@@ -52,7 +52,7 @@ class PostMapper extends Mapper
             foreach ($contentBlockContent as $contentBlock) {
                 $result = $contentBlock->{'blog-post-content'}->result;
 
-                if (is_object($result->metadata) && $contentBlockMapper->getDomainModel($result)) {
+                if (\is_object($result->metadata) && $contentBlockMapper->getDomainModel($result)) {
                     $contentBlocks[] = $contentBlockMapper->getDomainModel($result);
                 }
             }
@@ -64,7 +64,7 @@ class PostMapper extends Mapper
                     $tagMetadata = $tag->{'tag'}->result->metadata;
                     $formMetaData = $this->getFormMetaData($tag->{'tag'}->result);
 
-                    if (is_object($formMetaData) && !is_null($tagMetadata)) {
+                    if (\is_object($formMetaData) && !\is_null($tagMetadata)) {
                         $tags[] = $this->mapperFactory->createTagMapper()->getDomainModel(
                             $tag->{'tag'}->result
                         );

--- a/src/BlogsService/Mapper/IsiteToDomain/TagMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/TagMapper.php
@@ -14,7 +14,7 @@ class TagMapper extends Mapper
     {
         $formMetaData = $this->getFormMetaData($isiteObject);
 
-        if (!is_object($formMetaData)) {
+        if (!\is_object($formMetaData)) {
             return null;
         }
 

--- a/src/BlogsService/Repository/PostRepository.php
+++ b/src/BlogsService/Repository/PostRepository.php
@@ -160,7 +160,7 @@ class PostRepository extends AbstractRepository
     ): array {
         $queries = [];
         foreach ($months as $month) {
-            if (!is_int($month)) {
+            if (!\is_int($month)) {
                 throw new InvalidArgumentException('Argument months must be an array of integers');
             }
 

--- a/src/Ds/Author/AuthorSummary/AuthorSummaryPresenter.php
+++ b/src/Ds/Author/AuthorSummary/AuthorSummaryPresenter.php
@@ -49,7 +49,7 @@ class AuthorSummaryPresenter extends Presenter
     {
         parent::validateOptions($options);
 
-        if (!is_int($options['h_tag'])) {
+        if (!\is_int($options['h_tag'])) {
             throw new InvalidOptionException("Option 'h_tag' must be an int");
         }
     }

--- a/src/Ds/Molecule/Image/ImagePresenter.php
+++ b/src/Ds/Molecule/Image/ImagePresenter.php
@@ -43,8 +43,8 @@ class ImagePresenter extends Presenter
     ) {
         parent::__construct($options);
 
-        if ((!is_string($sizes) && !is_array($sizes)) ||
-            (is_array($sizes) && (!empty($sizes) && array_values($sizes) === $sizes))
+        if ((!\is_string($sizes) && !\is_array($sizes)) ||
+            (\is_array($sizes) && (!empty($sizes) && array_values($sizes) === $sizes))
         ) {
             throw new InvalidArgumentException("Argument 'sizes' must be either an empty or associative array, or a string");
         }
@@ -79,11 +79,11 @@ class ImagePresenter extends Presenter
     {
         parent::validateOptions($options);
 
-        if (!is_bool($options['is_lazy_loaded'])) {
+        if (!\is_bool($options['is_lazy_loaded'])) {
             throw new InvalidOptionException("Option 'is_lazy_loaded' must be a boolean");
         }
 
-        if (!is_array($options['srcsets'])) {
+        if (!\is_array($options['srcsets'])) {
             throw new InvalidOptionException("Option 'srcsets' must be an array");
         }
 
@@ -97,7 +97,7 @@ class ImagePresenter extends Presenter
             throw new InvalidOptionException("Option 'ratio' must be numeric or null");
         }
 
-        if (!is_string($options['alt'])) {
+        if (!\is_string($options['alt'])) {
             throw new InvalidOptionException("Option 'alt' must be a string");
         }
     }
@@ -108,7 +108,7 @@ class ImagePresenter extends Presenter
      */
     private function buildSizes($sizes): string
     {
-        if (is_string($sizes)) {
+        if (\is_string($sizes)) {
             return $sizes;
         }
 
@@ -120,7 +120,7 @@ class ImagePresenter extends Presenter
         foreach ($sizes as $width => $fraction) {
             $width = ($width / 16);
 
-            if (!is_string($fraction)) {
+            if (!\is_string($fraction)) {
                 // Convert to percentage and append the 'vw'
                 $fraction = ($fraction * 100);
                 $fraction .= 'vw';

--- a/src/Ds/Post/Author/AuthorPresenter.php
+++ b/src/Ds/Post/Author/AuthorPresenter.php
@@ -61,7 +61,7 @@ class AuthorPresenter extends Presenter
     {
         parent::validateOptions($options);
 
-        if (!is_bool($options['is_slimline'])) {
+        if (!\is_bool($options['is_slimline'])) {
             throw new InvalidOptionException("Option 'is_lazy_loaded' must be a boolean");
         }
     }

--- a/src/Ds/Post/PostSummary/PostSummaryPresenter.php
+++ b/src/Ds/Post/PostSummary/PostSummaryPresenter.php
@@ -63,23 +63,23 @@ class PostSummaryPresenter extends Presenter
     {
         parent::validateOptions($options);
 
-        if (!is_array($options['author_options'])) {
+        if (!\is_array($options['author_options'])) {
             throw new InvalidOptionException("Option 'author_options' must be an array");
         }
 
-        if (!is_string($options['h_class'])) {
+        if (!\is_string($options['h_class'])) {
             throw new InvalidOptionException("Option 'h_class' must be a string");
         }
 
-        if (!is_int($options['h_tag'])) {
+        if (!\is_int($options['h_tag'])) {
             throw new InvalidOptionException("Option 'h_tag' must be an int");
         }
 
-        if (!is_bool($options['show_author'])) {
+        if (!\is_bool($options['show_author'])) {
             throw new InvalidOptionException("Option 'show_author' must be a boolean");
         }
 
-        if (!is_bool($options['show_image'])) {
+        if (!\is_bool($options['show_image'])) {
             throw new InvalidOptionException("Option 'show_image' must be a boolean");
         }
     }

--- a/src/Exception/CouldNotMapPostException.php
+++ b/src/Exception/CouldNotMapPostException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Exception;
+
+use Exception;
+
+class CouldNotMapPostException extends Exception
+{
+}

--- a/src/Exception/PostMappingException.php
+++ b/src/Exception/PostMappingException.php
@@ -5,6 +5,6 @@ namespace App\Exception;
 
 use Exception;
 
-class CouldNotMapPostException extends Exception
+class PostMappingException extends Exception
 {
 }

--- a/src/Translate/TranslatableTrait.php
+++ b/src/Translate/TranslatableTrait.php
@@ -58,11 +58,11 @@ trait TranslatableTrait
         $numPlurals = null,
         ?string $domain = null
     ): string {
-        if (is_int($substitutions) && is_null($numPlurals)) {
+        if (\is_int($substitutions) && \is_null($numPlurals)) {
             $numPlurals = $substitutions;
             $substitutions = ['%count%' => $numPlurals];
         }
-        if (is_int($numPlurals) && !isset($substitutions['%count%'])) {
+        if (\is_int($numPlurals) && !isset($substitutions['%count%'])) {
             $substitutions['%count%'] = $numPlurals;
         }
         return $this->translateProvider->getTranslate()->translate($key, $substitutions, $numPlurals, $domain);

--- a/tests/BlogsService/Infrastructure/MapperFactoryTest.php
+++ b/tests/BlogsService/Infrastructure/MapperFactoryTest.php
@@ -10,6 +10,7 @@ use App\BlogsService\Mapper\IsiteToDomain\ModuleMapper;
 use App\BlogsService\Mapper\IsiteToDomain\PostMapper;
 use App\BlogsService\Mapper\IsiteToDomain\TagMapper;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class MapperFactoryTest extends TestCase
 {
@@ -18,7 +19,7 @@ class MapperFactoryTest extends TestCase
 
     public function setUp()
     {
-        $this->mapperFactory = new MapperFactory();
+        $this->mapperFactory = new MapperFactory($this->createMock(LoggerInterface::class));
     }
 
     /** @dataProvider isiteDataProvider */

--- a/tests/BlogsService/Mapper/IsiteToDomain/AuthorMapperTest.php
+++ b/tests/BlogsService/Mapper/IsiteToDomain/AuthorMapperTest.php
@@ -5,6 +5,7 @@ namespace Tests\App\BlogsService\Mapper\IsiteToDomain;
 
 use App\BlogsService\Infrastructure\MapperFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 class AuthorMapperTest extends TestCase
@@ -22,7 +23,7 @@ class AuthorMapperTest extends TestCase
 
     public function testGetsDomainModel()
     {
-        $mapperFactory = new MapperFactory();
+        $mapperFactory = new MapperFactory($this->createMock(LoggerInterface::class));
 
         $authorMapper = $mapperFactory->createAuthorsMapper();
         $domainModel = $authorMapper->getDomainModel($this->isiteObject);

--- a/tests/BlogsService/Mapper/IsiteToDomain/BlogMapperTest.php
+++ b/tests/BlogsService/Mapper/IsiteToDomain/BlogMapperTest.php
@@ -7,6 +7,7 @@ use App\BlogsService\Infrastructure\MapperFactory;
 use App\BlogsService\Mapper\IsiteToDomain\BlogMapper;
 use App\BlogsService\Mapper\IsiteToDomain\PostMapper;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 class BlogMapperTest extends TestCase
@@ -20,7 +21,7 @@ class BlogMapperTest extends TestCase
         $isiteObject = new SimpleXMLElement($xml);
 
         $mapperFactory = $this->createMock(MapperFactory::class);
-        $blogMapper = new BlogMapper($mapperFactory);
+        $blogMapper = new BlogMapper($mapperFactory, $this->createMock(LoggerInterface::class));
 
         /** @var Blog $domainModel */
         $domainModel = $blogMapper->getDomainModel($isiteObject);
@@ -48,9 +49,9 @@ class BlogMapperTest extends TestCase
         $isiteObject = new SimpleXMLElement($xml);
 
         $mapperFactory = $this->createMock(MapperFactory::class);
-        $postMapper = new PostMapper($mapperFactory);
+        $postMapper = new PostMapper($mapperFactory, $this->createMock(LoggerInterface::class));
         $mapperFactory->method('createPostMapper')->willReturn($postMapper);
-        $blogMapper = new BlogMapper($mapperFactory);
+        $blogMapper = new BlogMapper($mapperFactory, $this->createMock(LoggerInterface::class));
 
         /** @var Blog $domainModel */
         $blog = $blogMapper->getDomainModel($isiteObject);

--- a/tests/BlogsService/Mapper/IsiteToDomain/PostMapperTest.php
+++ b/tests/BlogsService/Mapper/IsiteToDomain/PostMapperTest.php
@@ -8,6 +8,7 @@ use App\BlogsService\Mapper\IsiteToDomain\AuthorMapper;
 use App\BlogsService\Mapper\IsiteToDomain\ContentBlockMapper;
 use App\BlogsService\Mapper\IsiteToDomain\PostMapper;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 class PostMapperTest extends TestCase
@@ -21,7 +22,7 @@ class PostMapperTest extends TestCase
         $isiteObject = new SimpleXMLElement($xml);
 
         $mapperFactory = $this->createMock(MapperFactory::class);
-        $postMapper = new PostMapper($mapperFactory);
+        $postMapper = new PostMapper($mapperFactory, $this->createMock(LoggerInterface::class));
 
         /** @var Post $domainModel */
         $domainModel = $postMapper->getDomainModel($isiteObject);
@@ -46,13 +47,13 @@ class PostMapperTest extends TestCase
 
         $mapperFactory = $this->createMock(MapperFactory::class);
 
-        $contentBlockMapper = new ContentBlockMapper($mapperFactory);
-        $authorMapper = new AuthorMapper($mapperFactory);
+        $contentBlockMapper = new ContentBlockMapper($mapperFactory, $this->createMock(LoggerInterface::class));
+        $authorMapper = new AuthorMapper($mapperFactory, $this->createMock(LoggerInterface::class));
 
         $mapperFactory->method('createContentBlockMapper')->willReturn($contentBlockMapper);
         $mapperFactory->method('createAuthorsMapper')->willReturn($authorMapper);
 
-        $postMapper = new PostMapper($mapperFactory);
+        $postMapper = new PostMapper($mapperFactory, $this->createMock(LoggerInterface::class));
 
         /** @var Post $domainModel */
         $domainModel = $postMapper->getDomainModel($isiteObject);


### PR DESCRIPTION
A couple of tweaks and bug fixes as a result of load tests:

Guzzle Timeouts
-
Have slightly increased the connect timeout, but reduced overall timeout to 20s 

PHP/nginx
-
- Reduce `max_children` to reduce timeouts
- Add fastcgi_buffers as per [this pr](https://github.com/bbc/programmes-frontend/pull/388)

OPCache
-
- Updated as per Symfony recommendations. Reduced `memory_consumption` value to 128m after profiling showed this was sufficient.
- Fully qualify appropriate root namespace function calls in mappers to exploit caching

Bug Fixes
-
- Stop blindly catching all `Exception`s in the `PostMapper` 
- Skip an invalid content block and log and error 
- Skip new exceptions thrown by invalid Featured Post