### PR TITLE
BLOG-1344: Bug Fixes

### DIFF
--- a/src/BlogsService/Mapper/IsiteToDomain/ContentBlockMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/ContentBlockMapper.php
@@ -8,8 +8,6 @@ use App\BlogsService\Domain\ContentBlock\Code;
 use App\BlogsService\Domain\ContentBlock\Image;
 use App\BlogsService\Domain\ContentBlock\Prose;
 use App\BlogsService\Domain\ContentBlock\Social;
-use App\BlogsService\Infrastructure\MapperFactory;
-use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 class ContentBlockMapper extends Mapper

--- a/src/BlogsService/Mapper/IsiteToDomain/TagMapper.php
+++ b/src/BlogsService/Mapper/IsiteToDomain/TagMapper.php
@@ -22,7 +22,7 @@ class TagMapper extends Mapper
 
         try {
             $fileId = $this->getString($this->getMetaData($isiteObject)->fileId);
-            $fileId = str_replace('blogs-', '', $fileId);
+            $fileId = preg_replace('/^blogs-/', '', $fileId);
 
             return new Tag(new FileID($fileId), $name);
         } catch (Exception $e) {

--- a/src/BlogsService/Repository/PostRepository.php
+++ b/src/BlogsService/Repository/PostRepository.php
@@ -225,4 +225,30 @@ class PostRepository extends AbstractRepository
 
         return $this->getResponse($query);
     }
+
+    /** @return ResponseInterface[] */
+    public function getPostsByTagFileIds(string $blogId, array $tagIds, int $page, int $perpage): array
+    {
+        $queries = [];
+        foreach($tagIds as $key => $tagId) {
+            $query = new SearchQuery();
+            $query->setProject($blogId);
+            $query->setNamespace($blogId, 'blogs-post');
+            $query->setQuery(['ns:tag', 'contains', $tagId]);
+            $query->setSort([
+                [
+                    'elementPath' => '/ns:form/ns:metadata/ns:published-date',
+                    'direction' => 'desc',
+                ],
+            ]);
+            $query->setDepth(1);
+            $query->setPage($page);
+            $query->setPageSize($perpage);
+            $query->setUnfiltered(true);
+
+            $queries[$key] = $query;
+        }
+
+        return $this->getParallelResponses($queries);
+    }
 }

--- a/src/BlogsService/Repository/PostRepository.php
+++ b/src/BlogsService/Repository/PostRepository.php
@@ -230,7 +230,7 @@ class PostRepository extends AbstractRepository
     public function getPostsByTagFileIds(string $blogId, array $tagIds, int $page, int $perpage): array
     {
         $queries = [];
-        foreach($tagIds as $key => $tagId) {
+        foreach ($tagIds as $key => $tagId) {
             $query = new SearchQuery();
             $query->setProject($blogId);
             $query->setNamespace($blogId, 'blogs-post');

--- a/src/BlogsService/Repository/PostRepository.php
+++ b/src/BlogsService/Repository/PostRepository.php
@@ -206,26 +206,6 @@ class PostRepository extends AbstractRepository
         return $this->getParallelResponses($queries);
     }
 
-    public function getPostsByTagFileId(string $blogId, string $tagFileId, int $page, int $perpage): ?ResponseInterface
-    {
-        $query = new SearchQuery();
-        $query->setProject($blogId);
-        $query->setNamespace($blogId, 'blogs-post');
-        $query->setQuery(['ns:tag', 'contains', $tagFileId]);
-        $query->setSort([
-            [
-                'elementPath' => '/ns:form/ns:metadata/ns:published-date',
-                'direction' => 'desc',
-            ],
-        ]);
-        $query->setDepth(1);
-        $query->setPage($page);
-        $query->setPageSize($perpage);
-        $query->setUnfiltered(true);
-
-        return $this->getResponse($query);
-    }
-
     /** @return ResponseInterface[] */
     public function getPostsByTagFileIds(string $blogId, array $tagIds, int $page, int $perpage): array
     {

--- a/src/BlogsService/Service/AuthorService.php
+++ b/src/BlogsService/Service/AuthorService.php
@@ -6,10 +6,10 @@ namespace App\BlogsService\Service;
 use App\BlogsService\Domain\Author;
 use App\BlogsService\Domain\Blog;
 use App\BlogsService\Domain\ValueObject\GUID;
-use BBC\ProgrammesCachingLibrary\CacheInterface;
 use App\BlogsService\Infrastructure\IsiteFeedResponseHandler;
 use App\BlogsService\Infrastructure\IsiteResult;
 use App\BlogsService\Repository\AuthorRepository;
+use BBC\ProgrammesCachingLibrary\CacheInterface;
 
 class AuthorService
 {

--- a/src/BlogsService/Service/BlogService.php
+++ b/src/BlogsService/Service/BlogService.php
@@ -4,10 +4,10 @@ declare(strict_types = 1);
 namespace App\BlogsService\Service;
 
 use App\BlogsService\Domain\Blog;
-use BBC\ProgrammesCachingLibrary\CacheInterface;
 use App\BlogsService\Infrastructure\IsiteFeedResponseHandler;
 use App\BlogsService\Infrastructure\IsiteResult;
 use App\BlogsService\Repository\BlogRepository;
+use BBC\ProgrammesCachingLibrary\CacheInterface;
 
 class BlogService
 {

--- a/src/BlogsService/Service/PostService.php
+++ b/src/BlogsService/Service/PostService.php
@@ -274,20 +274,18 @@ class PostService
         $ttl = CacheInterface::X_LONG,
         $nullTtl = CacheInterface::NONE
     ): array {
-        $tagIds = array_map(
-            function (Tag $tag) {
-                return (string) $tag->getFileId();
-            },
-            $tags
-        );
+        $tagFileIds = [];
+        foreach ($tags as $tag) {
+            $tagFileIds[$tag->getId()] = (string) $tag->getFileId();
+        }
 
-        $cacheKey = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $blog->getId(), join('_', $tagIds));
+        $cacheKey = $this->cache->keyHelper(__CLASS__, __FUNCTION__, $blog->getId(), join('_', $tagFileIds));
 
         return $this->cache->getOrSet(
             $cacheKey,
             $ttl,
-            function () use ($blog, $tagIds) {
-                $responses = $this->repository->getPostsByTagFileIds($blog->getId(), $tagIds, 1, 1);
+            function () use ($blog, $tagFileIds) {
+                $responses = $this->repository->getPostsByTagFileIds($blog->getId(), $tagFileIds, 1, 1);
 
                 $result = [];
 

--- a/src/BlogsService/Service/PostService.php
+++ b/src/BlogsService/Service/PostService.php
@@ -259,8 +259,8 @@ class PostService
             $cacheKey,
             $ttl,
             function () use ($blog, $tag, $page, $perpage) {
-                $response = $this->repository->getPostsByTagFileId($blog->getId(), (string) $tag->getFileId(), $page, $perpage);
-                return $this->responseHandler->getIsiteResult($response);
+                $response = $this->repository->getPostsByTagFileIds($blog->getId(), [(string) $tag->getFileId()], $page, $perpage);
+                return $this->responseHandler->getIsiteResult($response[0]);
             },
             [],
             $nullTtl

--- a/src/BlogsService/Service/PostService.php
+++ b/src/BlogsService/Service/PostService.php
@@ -8,10 +8,10 @@ use App\BlogsService\Domain\Blog;
 use App\BlogsService\Domain\Post;
 use App\BlogsService\Domain\Tag;
 use App\BlogsService\Domain\ValueObject\GUID;
-use BBC\ProgrammesCachingLibrary\CacheInterface;
 use App\BlogsService\Infrastructure\IsiteFeedResponseHandler;
 use App\BlogsService\Infrastructure\IsiteResult;
 use App\BlogsService\Repository\PostRepository;
+use BBC\ProgrammesCachingLibrary\CacheInterface;
 use Cake\Chronos\Chronos;
 
 class PostService

--- a/src/BlogsService/Service/PostService.php
+++ b/src/BlogsService/Service/PostService.php
@@ -287,7 +287,7 @@ class PostService
             $cacheKey,
             $ttl,
             function () use ($blog, $tagIds) {
-                $responses = $this->repository->getPostsByTagFileIds($blog->getId(), $tagIds, 1,1);
+                $responses = $this->repository->getPostsByTagFileIds($blog->getId(), $tagIds, 1, 1);
 
                 $result = [];
 

--- a/src/BlogsService/Service/ServiceFactory.php
+++ b/src/BlogsService/Service/ServiceFactory.php
@@ -2,7 +2,6 @@
 declare(strict_types = 1);
 namespace App\BlogsService\Service;
 
-use BBC\ProgrammesCachingLibrary\Cache;
 use App\BlogsService\Infrastructure\IsiteFeedResponseHandler;
 use App\BlogsService\Infrastructure\MapperFactory;
 use App\BlogsService\Infrastructure\XmlParser;
@@ -10,6 +9,7 @@ use App\BlogsService\Repository\AuthorRepository;
 use App\BlogsService\Repository\BlogRepository;
 use App\BlogsService\Repository\PostRepository;
 use App\BlogsService\Repository\TagRepository;
+use BBC\ProgrammesCachingLibrary\Cache;
 use GuzzleHttp\ClientInterface;
 
 class ServiceFactory

--- a/src/BlogsService/Service/TagService.php
+++ b/src/BlogsService/Service/TagService.php
@@ -5,10 +5,10 @@ namespace App\BlogsService\Service;
 
 use App\BlogsService\Domain\Blog;
 use App\BlogsService\Domain\Tag;
-use BBC\ProgrammesCachingLibrary\CacheInterface;
 use App\BlogsService\Infrastructure\IsiteFeedResponseHandler;
 use App\BlogsService\Infrastructure\IsiteResult;
 use App\BlogsService\Repository\TagRepository;
+use BBC\ProgrammesCachingLibrary\CacheInterface;
 
 class TagService
 {

--- a/src/Controller/TagIndexController.php
+++ b/src/Controller/TagIndexController.php
@@ -4,12 +4,13 @@ declare(strict_types = 1);
 namespace App\Controller;
 
 use App\BlogsService\Domain\Blog;
+use App\BlogsService\Service\PostService;
 use App\BlogsService\Service\TagService;
 use Symfony\Component\HttpFoundation\Request;
 
 class TagIndexController extends BlogsBaseController
 {
-    public function __invoke(Request $request, Blog $blog, TagService $tagService)
+    public function __invoke(Request $request, Blog $blog, TagService $tagService, PostService $postService)
     {
         $this->setBlog($blog);
         $this->counterName = 'tags';
@@ -20,12 +21,15 @@ class TagIndexController extends BlogsBaseController
 
         $tagsResult = $tagService->getTagsByBlog($blog, $page, 10);
 
+        $tagPostCounts = $postService->getPostCountsForTags($blog, $tagsResult->getDomainModels());
+
         $paginator = $this->createPaginator($tagsResult);
 
         return $this->renderWithChrome(
             'tag/index.html.twig',
             [
                 'tagResult' => $tagsResult,
+                'tagPostCounts' => $tagPostCounts,
                 'paginatorPresenter' => $paginator,
             ]
         );

--- a/src/Controller/TagShowController.php
+++ b/src/Controller/TagShowController.php
@@ -33,10 +33,6 @@ class TagShowController extends BlogsBaseController
             10
         );
 
-        if ($postResults->getTotal() === 0) {
-            throw $this->createNotFoundException('No posts were found for the tag ' . $tag->getName());
-        }
-
         $paginator = $this->createPaginator($postResults);
 
         return $this->renderWithChrome(

--- a/src/Service/CommentsService.php
+++ b/src/Service/CommentsService.php
@@ -6,7 +6,6 @@ namespace App\Service;
 use App\BlogsService\Domain\Blog;
 use App\BlogsService\Domain\Post;
 use App\Translate\TranslateProvider;
-use BBC\ProgrammesMorphLibrary\Entity\MorphView;
 use BBC\ProgrammesMorphLibrary\MorphClient;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Log\LoggerInterface;

--- a/templates/tag/index.html.twig
+++ b/templates/tag/index.html.twig
@@ -21,6 +21,12 @@
                     <li class="br-keyline delta">
                         <a data-istats-link-location="blogs_global_tag" href="{{ path('tag_show', {blogId: blog.getId(), tagId: tag.getId()}) }}">
                             {{- tag.getName() -}}
+
+                            {% if not tagPostCounts[loop.index0] is empty %}
+                                <p class="pull--right no-margin text--shout deemphasize br-page-text-ontext">
+                                    {{ tr('post', tagPostCounts[loop.index0]) }}
+                                </p>
+                            {% endif %}
                         </a>
                     </li>
                 {%- endfor -%}

--- a/templates/tag/index.html.twig
+++ b/templates/tag/index.html.twig
@@ -23,9 +23,9 @@
                             <h2 class="delta pull--left no-margin">
                                 {{- tag.getName() -}}
                             </h2>
-                            {% if not tagPostCounts[loop.index0] is empty %}
+                            {% if not tagPostCounts[tag.getId()] is empty %}
                                 <p class="pull--right no-margin text--shout deemphasize br-page-text-ontext">
-                                    {{- tr('post', tagPostCounts[loop.index0]) -}}
+                                    {{- tr('post', tagPostCounts[tag.getId()]) -}}
                                 </p>
                             {% endif %}
                         </a>

--- a/templates/tag/index.html.twig
+++ b/templates/tag/index.html.twig
@@ -18,13 +18,14 @@
         {%- else -%}
             <ul class="list-unstyled list-lined">
                 {%- for tag in tagResult.getDomainModels() -%}
-                    <li class="br-keyline delta">
+                    <li class="br-keyline cf">
                         <a data-istats-link-location="blogs_global_tag" href="{{ path('tag_show', {blogId: blog.getId(), tagId: tag.getId()}) }}">
-                            {{- tag.getName() -}}
-
+                            <h2 class="delta pull--left no-margin">
+                                {{- tag.getName() -}}
+                            </h2>
                             {% if not tagPostCounts[loop.index0] is empty %}
                                 <p class="pull--right no-margin text--shout deemphasize br-page-text-ontext">
-                                    {{ tr('post', tagPostCounts[loop.index0]) }}
+                                    {{- tr('post', tagPostCounts[loop.index0]) -}}
                                 </p>
                             {% endif %}
                         </a>

--- a/tests/Controller/TagIndexControllerTest.php
+++ b/tests/Controller/TagIndexControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Tests\App\Controller;
 
 use App\BlogsService\Domain\Tag;
+use App\BlogsService\Domain\ValueObject\FileID;
 use App\BlogsService\Infrastructure\IsiteResult;
 use App\BlogsService\Service\PostService;
 use App\BlogsService\Service\TagService;
@@ -26,11 +27,11 @@ class TagIndexControllerTest extends BaseWebTestCase
     {
         $crawler = $this->getCrawlerForPage(
             [
-                TagBuilder::default()->withName('First Tag')->build(),
-                TagBuilder::default()->build(),
-                TagBuilder::default()->build(),
+                TagBuilder::default()->withName('First Tag')->withFileId(new FileID('tag-t1'))->build(),
+                TagBuilder::default()->withFileId(new FileID('tag-t2'))->build(),
+                TagBuilder::default()->withFileId(new FileID('tag-t3'))->build(),
             ],
-            [1, 2, 3]
+            ['t1' => 1, 't2' => 2, 't3' => 3]
         );
 
         $this->assertTagsTitle($crawler, 'Tags (3)');

--- a/tests/Controller/TagIndexControllerTest.php
+++ b/tests/Controller/TagIndexControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\App\Controller;
 
 use App\BlogsService\Domain\Tag;
 use App\BlogsService\Infrastructure\IsiteResult;
+use App\BlogsService\Service\PostService;
 use App\BlogsService\Service\TagService;
 use Symfony\Component\DomCrawler\Crawler;
 use Tests\App\BaseWebTestCase;
@@ -23,11 +24,14 @@ class TagIndexControllerTest extends BaseWebTestCase
 
     public function testBlogWithTags()
     {
-        $crawler = $this->getCrawlerForPage([
-            TagBuilder::default()->withName('First Tag')->build(),
-            TagBuilder::default()->build(),
-            TagBuilder::default()->build(),
-        ]);
+        $crawler = $this->getCrawlerForPage(
+            [
+                TagBuilder::default()->withName('First Tag')->build(),
+                TagBuilder::default()->build(),
+                TagBuilder::default()->build(),
+            ],
+            [1, 2, 3]
+        );
 
         $this->assertTagsTitle($crawler, 'Tags (3)');
 
@@ -36,14 +40,16 @@ class TagIndexControllerTest extends BaseWebTestCase
 
         $this->assertEquals(3, $tagsDisplayed->count());
 
-        $firstTag = $tagsDisplayed->first()->filterXPath('//a');
-
+        $firstTag = $tagsDisplayed->first()->filterXPath('//h2');
         $this->assertEquals('First Tag', $firstTag->text());
+
+        $firstTagCount = $tagsDisplayed->first()->filterXPath('//p');
+        $this->assertEquals('1 post', $firstTagCount->text());
     }
 
     public function testBlogNoTags()
     {
-        $crawler = $this->getCrawlerForPage([]);
+        $crawler = $this->getCrawlerForPage([], []);
 
         $this->assertTagsTitle($crawler, 'Tags (0)');
 
@@ -61,7 +67,7 @@ class TagIndexControllerTest extends BaseWebTestCase
      * @param Tag[] $tags
      * @return Crawler
      */
-    private function getCrawlerForPage(array $tags): Crawler
+    private function getCrawlerForPage(array $tags, array $tagPostCounts): Crawler
     {
         $iSiteResult = new IsiteResult(1, 10, count($tags), $tags);
 
@@ -72,6 +78,11 @@ class TagIndexControllerTest extends BaseWebTestCase
             ->willReturn($iSiteResult);
 
         $this->client->getContainer()->set(TagService::class, $tagService);
+
+        $postService = $this->createMock(PostService::class);
+        $postService->method('getPostCountsForTags')->willReturn($tagPostCounts);
+
+        $this->client->getContainer()->set(PostService::class, $postService);
 
         return $this->client->request('GET', '/blogs/testblog/tags');
     }

--- a/tests/Controller/TagShowControllerTest.php
+++ b/tests/Controller/TagShowControllerTest.php
@@ -46,12 +46,16 @@ class TagShowControllerTest extends BaseWebTestCase
 
     public function testTagShowNoPosts()
     {
-        $this->getCrawlerForPage(
+        $crawler = $this->getCrawlerForPage(
             TagBuilder::default()->withName('Test Tag')->build(),
             []
         );
 
-        $this->assertResponseStatusCode($this->client, 404);
+        $title = $crawler->filterXPath('//div//h1')->first()->text();
+        $this->assertEquals('Tagged with: Test Tag', $title);
+
+        $title = $crawler->filterXPath('//div//p')->first()->text();
+        $this->assertEquals('There are no results', $title);
     }
 
     public function testNoTag()


### PR DESCRIPTION
Have compared new implementation with the acceptance criteria which has prompted the following changes:
- Fix regex removing `'blogs-'` prefix from a tag `FileId` so it only removes occurrences from the beginning of the string
- Don't throw a 404 if there are no posts for a tag that exists, instead display the `There are no posts` message
- Add post counts to Tag Index page, fetched concurrently
- Refactor `getPostsByTag` service method to now use the new `PostRepository` method