### PR TITLE
Use both English Translations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -136,16 +136,16 @@
         },
         {
             "name": "bbc-rmp/translate",
-            "version": "v1.8.7",
+            "version": "v1.8.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bbc/rmp-translate.git",
-                "reference": "a73646db5264288f286e442f72a9360e9e0e00a5"
+                "reference": "04751a04a556b4c960e96ad01a69135568cb82b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bbc/rmp-translate/zipball/a73646db5264288f286e442f72a9360e9e0e00a5",
-                "reference": "a73646db5264288f286e442f72a9360e9e0e00a5",
+                "url": "https://api.github.com/repos/bbc/rmp-translate/zipball/04751a04a556b4c960e96ad01a69135568cb82b7",
+                "reference": "04751a04a556b4c960e96ad01a69135568cb82b7",
                 "shasum": ""
             },
             "require": {
@@ -175,10 +175,10 @@
             ],
             "description": "Small PHP library and translation files for translations in programmes/amen",
             "support": {
-                "source": "https://github.com/bbc/rmp-translate/tree/master",
+                "source": "https://github.com/bbc/rmp-translate/tree/v1.8.8",
                 "issues": "https://github.com/bbc/rmp-translate/issues"
             },
-            "time": "2017-11-01T10:58:17+00:00"
+            "time": "2018-02-26T15:49:52+00:00"
         },
         {
             "name": "bbc/branding-client",

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -125,6 +125,12 @@ abstract class BaseController extends AbstractController
 
     protected function setLocale(string $locale)
     {
+        // The translations library doesn't support multiple variations of the same language
+        // so this allows us to have two different versions of English
+        if ($locale === 'en-GB_articles') {
+            $locale = 'articles';
+        }
+
         $this->locale = $locale;
     }
 

--- a/translations/blogs/articles.po
+++ b/translations/blogs/articles.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bbc blogs v5\n"
-"Language: eb_GB\n"
+"Language: en_GB\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==0 ? 0 : n==1 ? 1 : 2)\n"


### PR DESCRIPTION
In /blogs, editorial can choose between two variants of English: 
'Latest News' & 'Articles' / 'Blog' & 'Posts'

Depends on [this PR](https://github.com/bbc/rmp-translate/pull/60) before merging