### PR TITLE
remove dependency security checker until we find a fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "csa/guzzle-bundle": "^3.1",
         "fzaninotto/faker": "^1.8",
         "incenteev/composer-parameter-handler": "^2.1",
-        "sensiolabs/security-checker": "^4.1",
         "symfony/asset": "^4.0",
         "symfony/console": "^4.0",
         "symfony/flex": "^1.0",
@@ -84,8 +83,7 @@
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd",
-            "security-checker security:check": "script"
+            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfc252b47f8b9e02df1e3d1ccf3ea0a5",
+    "content-hash": "82c2a13558121e26a692a4d321b3c4bc",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -492,62 +492,6 @@
                 "utility"
             ],
             "time": "2018-05-31T20:11:56+00:00"
-        },
-        {
-            "name": "composer/ca-bundle",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "d2c0a83b7533d6912e8d516756ebd34f893e9169"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/d2c0a83b7533d6912e8d516756ebd34f893e9169",
-                "reference": "d2c0a83b7533d6912e8d516756ebd34f893e9169",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-                "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "time": "2018-03-29T19:57:20+00:00"
         },
         {
             "name": "csa/guzzle-bundle",
@@ -1460,51 +1404,6 @@
                 "simple-cache"
             ],
             "time": "2017-10-23T01:57:42+00:00"
-        },
-        {
-            "name": "sensiolabs/security-checker",
-            "version": "v4.1.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "dc270d5fec418cc6ac983671dba5d80ffaffb142"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/dc270d5fec418cc6ac983671dba5d80ffaffb142",
-                "reference": "dc270d5fec418cc6ac983671dba5d80ffaffb142",
-                "shasum": ""
-            },
-            "require": {
-                "composer/ca-bundle": "^1.0",
-                "symfony/console": "~2.7|~3.0|~4.0"
-            },
-            "bin": [
-                "security-checker"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "SensioLabs\\Security": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien.potencier@gmail.com"
-                }
-            ],
-            "description": "A security checker for your composer.lock",
-            "time": "2018-02-28T22:10:01+00:00"
         },
         {
             "name": "symfony/asset",

--- a/config/packages/dev/security_checker.yaml
+++ b/config/packages/dev/security_checker.yaml
@@ -1,8 +1,0 @@
-services:
-    SensioLabs\Security\SecurityChecker:
-        public: false
-
-    SensioLabs\Security\Command\SecurityCheckerCommand:
-        arguments: ['@SensioLabs\Security\SecurityChecker']
-        tags:
-            - { name: console.command }

--- a/symfony.lock
+++ b/symfony.lock
@@ -29,9 +29,6 @@
     "cakephp/utility": {
         "version": "3.5.7"
     },
-    "composer/ca-bundle": {
-        "version": "1.1.0"
-    },
     "composer/xdebug-handler": {
         "version": "1.1.0"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -218,15 +218,6 @@
     "sebastian/version": {
         "version": "2.0.1"
     },
-    "sensiolabs/security-checker": {
-        "version": "4.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "4.0",
-            "ref": "576d653444dade07f272c889d52fe4594caa4fc3"
-        }
-    },
     "squizlabs/php_codesniffer": {
         "version": "3.1.1"
     },


### PR DESCRIPTION
I had to remove it manually so I have done it based on how this was done for frontend 
https://github.com/bbc/programmes-frontend/pull/1024/commits/39780f3ff1443f2f6f77f9f39742b9ad07db9caa

I also compared with the commit when it was added to be sure I'm not missing anything https://github.com/bbc/blogs-frontend/commit/e204cb3c1dadbd872e519a75ac7f705740fd489c