### PR TITLE
[BLOGS-1425] Unpin the comments module version

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -74,7 +74,6 @@ services:
             - '@logger'
             - '@BBC\ProgrammesMorphLibrary\MorphClient'
             - '%app.feed_env.comments%'
-            - '%app.comments.version%'
 
     App\ValueObject\CosmosInfo:
         arguments: ['%cosmos_component_release%', '%cosmos_environment%', '%app.endpoint_host%']

--- a/src/Service/CommentsService.php
+++ b/src/Service/CommentsService.php
@@ -45,7 +45,6 @@ class CommentsService
                 'mode' => 'embedded',
                 'idctaEnv' => $this->env,
                 'forumId' => $this->getForumId($blog, $post),
-                'version' => $this->version,
             ],
             [],
             10

--- a/src/Service/CommentsService.php
+++ b/src/Service/CommentsService.php
@@ -26,13 +26,11 @@ class CommentsService
     public function __construct(
         LoggerInterface $logger,
         MorphClient $client,
-        string $env,
-        string $version
+        string $env
     ) {
         $this->env = $env;
         $this->client = $client;
         $this->logger = $logger;
-        $this->version = $version;
     }
 
     public function getByBlogAndPost(Blog $blog, Post $post): PromiseInterface


### PR DESCRIPTION
Ticket: https://jira.dev.bbc.co.uk/browse/BLOGS-1425

As part of this, we were asked to unpin the version of the comments module by the comments dev team rather than just version bump. As such, we have done.