### PR TITLE
programmes 7327 - fix feed with no short synopsis entries

### DIFF
--- a/src/FeedGenerator/FeedGenerator.php
+++ b/src/FeedGenerator/FeedGenerator.php
@@ -91,7 +91,6 @@ class FeedGenerator
 
         $feedItem->setTitle($post->getTitle());
         $feedItem->setLink($postUrl);
-        $feedItem->setDescription($post->getShortSynopsis());
         $feedItem->setDateModified($post->getDisplayDate()->getTimestamp());
         $feedItem->setDateCreated($post->getDisplayDate()->getTimestamp());
 
@@ -100,6 +99,19 @@ class FeedGenerator
         }
 
         $postContent = $this->generatePostFeedContent($post);
+
+        $synopsis = $post->getShortSynopsis();
+        if (!$synopsis) {
+            // we should not find ourselves here
+            // except when an editor forgets to put in a short synopsis and there's no UI to remind them
+            if ($postContent) {
+                $synopsis = explode('. ', strip_tags($postContent))[0];
+            } else {
+                // last resort
+                $synopsis = '...';
+            }
+        }
+        $feedItem->setDescription($synopsis);
 
         if ($type == 'atom') {
             $postContent = html_entity_decode($postContent, ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/PROGRAMMES-7327

https://jira.dev.bbc.co.uk/browse/OPS-241172

### Before:

<img width="944" alt="Screenshot 2020-09-14 at 12 33 19" src="https://user-images.githubusercontent.com/14101296/93081034-85db1700-f686-11ea-918d-9e9402e9e0f9.png">

<img width="943" alt="Screenshot 2020-09-14 at 12 33 04" src="https://user-images.githubusercontent.com/14101296/93081052-8b386180-f686-11ea-8530-905eddd218ab.png">


### After:

<img width="938" alt="Screenshot 2020-09-14 at 12 31 13" src="https://user-images.githubusercontent.com/14101296/93081059-8ecbe880-f686-11ea-962d-bbcfa2957ba3.png">

<img width="898" alt="Screenshot 2020-09-14 at 12 32 29" src="https://user-images.githubusercontent.com/14101296/93081064-912e4280-f686-11ea-8285-bc4b047b671e.png">
