### PR TITLE
Update caching headers

### DIFF
--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -56,6 +56,8 @@ abstract class BaseController extends AbstractController
         // It is required to set the cache-control header when creating the response object otherwise Symfony
         // will create and set its value to "no-cache, private" by default
         $this->response()->setPublic()->setMaxAge(300);
+        // Sets a grace period during which stale content may be served by BBC GTM Cache
+        $this->response()->headers->addCacheControlDirective('stale-while-revalidate', '30');
         // The page can only be displayed in a frame on the same origin as the page itself.
         $this->response()->headers->set('X-Frame-Options', 'SAMEORIGIN');
         // Blocks a request if the requested type is different from the MIME type

--- a/src/Controller/ExceptionController.php
+++ b/src/Controller/ExceptionController.php
@@ -85,7 +85,7 @@ class ExceptionController extends BaseExceptionController
 
         // In production, cache 4xx error codes for a little while
         if (!$showException && $code >= 400 && $code <= 499) {
-            $headers['Cache-Control'] = 'public, max-age=60';
+            $headers['Cache-Control'] = 'public, max-age=60, stale-while-revalidate=30';
         }
 
         // The 200 status here is a misnomer, it is a default and shall be

--- a/src/EventSubscriber/ResponseSubscriber.php
+++ b/src/EventSubscriber/ResponseSubscriber.php
@@ -45,12 +45,6 @@ class ResponseSubscriber implements EventSubscriberInterface
         // Content-Language is used to describe the language(s) intended for the audience
         $response->headers->set('Content-Language', $languageCode);
 
-        // X-Webapp is a BBC header to monitor Varnish hit/miss/pass/stale stats
-        $response->headers->set('X-Webapp', 'blogs-frontend');
-
-        // X-Cache-Control is a BBC Header, it sets a grace period during which stale content may be served by Varnish
-        $response->headers->set('X-Cache-Control', 'stale-while-revalidate=30');
-
         // "Fix" vary headers for Varnish. Despite multiple vary headers being RFC compliant
         // varnish does not like it. Join them into a single header here.
         $varyHeaders = $response->getVary();

--- a/tests/BaseWebTestCase.php
+++ b/tests/BaseWebTestCase.php
@@ -33,13 +33,11 @@ abstract class BaseWebTestCase extends WebTestCase
         $this->assertEquals($expectedLocation, $client->getResponse()->headers->get('location'));
     }
 
-    public function assertHasRequiredResponseHeaders($client, $cacheControl = 'max-age=300, public', $contentLanguage = null)
+    public function assertHasRequiredResponseHeaders($client, $cacheControl = 'max-age=300, public, stale-while-revalidate=30', $contentLanguage = null)
     {
         $this->assertEquals($cacheControl, $client->getResponse()->headers->get('Cache-Control'));
         $this->assertArraySubset(['X-CDN'], $client->getResponse()->getVary());
         $this->assertEquals('IE=edge', $client->getResponse()->headers->get('X-UA-Compatible'));
-        $this->assertEquals('blogs-frontend', $client->getResponse()->headers->get('X-Webapp'));
-        $this->assertEquals('stale-while-revalidate=30', $client->getResponse()->headers->get('X-Cache-Control'));
         if (isset($contentLanguage)) {
             $this->assertEquals($contentLanguage, $client->getResponse()->headers->get('Content-Language'));
         } else {

--- a/tests/Controller/ExceptionControllerTest.php
+++ b/tests/Controller/ExceptionControllerTest.php
@@ -17,7 +17,7 @@ class ExceptionControllerTest extends BaseWebTestCase
         // The test page for all errors, always returns a 200 status
         $this->assertResponseStatusCode($client, 200);
 
-        $this->assertHasRequiredResponseHeaders($client, 'max-age=60, public');
+        $this->assertHasRequiredResponseHeaders($client, 'max-age=60, public, stale-while-revalidate=30');
 
         $this->assertEquals(
             'Sorry, that page was not found',


### PR DESCRIPTION
Same as https://github.com/bbc/programmes-frontend/pull/1273 but for blogs
Move "stale-while-revalidate=30" from "X-Cache-Control" to "Cache-Control"
Remove X-Webapp which is no longer in use.